### PR TITLE
Adjust animations to look more natural and fix small issues

### DIFF
--- a/man/picom.1.asciidoc
+++ b/man/picom.1.asciidoc
@@ -60,6 +60,9 @@ OPTIONS
 	We use spring-based animations, which are parametrized by *--animation-stiffness*, *--animation-dampening* and *--animation-window-mass*. +
 	A useful resource for selecting animation parameters is https://react-spring-visualizer.com/, which allows you to interactively try out various parameters and see the resulting animation curve. Or you can just edit the values in the config file, which is automatically reloaded.
 
+*--animation-for-open-window*::
+	Which animation to run when opening a window. Must be one of `none`, `fly-in` (default: none).
+
 *--animation-stiffness*::
 	Stiffness (a.k.a. tension) parameter for spring-based animation (default: 200.0).
 

--- a/src/config.c
+++ b/src/config.c
@@ -503,6 +503,15 @@ void set_default_winopts(options_t *opt, win_option_mask_t *mask, bool shadow_en
 	}
 }
 
+enum open_window_animation parse_open_window_animation(const char *src) {
+	if (strcmp(src, "none") == 0) {
+		return OPEN_WINDOW_ANIMATION_NONE;
+	} else if (strcmp(src, "flyin") == 0) {
+		return OPEN_WINDOW_ANIMATION_FLYIN;
+	}
+	return OPEN_WINDOW_ANIMATION_INVALID;
+}
+
 char *parse_config(options_t *opt, const char *config_file, bool *shadow_enable,
                    bool *fading_enable, bool *hasneg, win_option_mask_t *winopt_mask) {
 	// clang-format off
@@ -548,6 +557,7 @@ char *parse_config(options_t *opt, const char *config_file, bool *shadow_enable,
 	    .fade_blacklist = NULL,
 
 	    .animations = false,
+	    .animation_for_open_window = OPEN_WINDOW_ANIMATION_NONE,
 	    .animation_stiffness = 200.0,
 	    .animation_window_mass = 1.0,
 	    .animation_dampening = 25,

--- a/src/config.h
+++ b/src/config.h
@@ -66,6 +66,12 @@ enum blur_method {
 	BLUR_METHOD_INVALID,
 };
 
+enum open_window_animation {
+	OPEN_WINDOW_ANIMATION_NONE = 0,
+	OPEN_WINDOW_ANIMATION_FLYIN,
+	OPEN_WINDOW_ANIMATION_INVALID,
+};
+
 typedef struct _c2_lptr c2_lptr_t;
 
 /// Structure representing all options.
@@ -172,6 +178,8 @@ typedef struct options {
 	// === Animations ===
 	/// Whether to do window animations
 	bool animations;
+	/// Which animation to run when opening a window
+	enum open_window_animation animation_for_open_window;
 	/// Spring stiffness for animation
 	double animation_stiffness;
 	/// Window mass for animation
@@ -268,6 +276,7 @@ struct conv **must_use parse_blur_kern_lst(const char *, bool *hasneg, int *coun
 bool must_use parse_geometry(session_t *, const char *, region_t *);
 bool must_use parse_rule_opacity(c2_lptr_t **, const char *);
 enum blur_method must_use parse_blur_method(const char *src);
+enum open_window_animation must_use parse_open_window_animation(const char *src);
 
 /**
  * Add a pattern to a condition linked list.

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -517,6 +517,15 @@ char *parse_config_libconfig(options_t *opt, const char *config_file, bool *shad
 	parse_cfg_condlst(&cfg, &opt->fade_blacklist, "fade-exclude");
 	// --animations
 	lcfg_lookup_bool(&cfg, "animations", &opt->animations);
+	// --animation-for-open-window
+	if (config_lookup_string(&cfg, "animation-for-open-window", &sval)) {
+		enum open_window_animation animation = parse_open_window_animation(sval);
+		if (animation >= OPEN_WINDOW_ANIMATION_INVALID) {
+			log_fatal("Invalid open-window animation %s", sval);
+			goto err;
+		}
+		opt->animation_for_open_window = animation;
+	}
 	// --animation-stiffness
 	config_lookup_float(&cfg, "animation-stiffness", &opt->animation_stiffness);
 	// --animation-window-mass

--- a/src/options.c
+++ b/src/options.c
@@ -74,6 +74,9 @@ static void usage(const char *argv0, int ret) {
 	    "--animations\n"
 	    "  Run animations for window geometry changes (movement and scaling).\n"
 	    "\n"
+	    "--animation-for-open-window\n"
+	    "  Which animation to run when opening a window. Must be one of `none`, `fly-in` (default: none).\n"
+	    "\n"
 	    "--animation-stiffness\n"
 	    "  Stiffness (a.k.a. tension) parameter for animation (default: 200.0).\n"
 	    "\n"
@@ -470,6 +473,7 @@ static const struct option longopts[] = {
     {"animation-stiffness", required_argument, NULL, 805},
     {"animation-dampening", required_argument, NULL, 806},
     {"animation-window-mass", required_argument, NULL, 807},
+    {"animation-for-open-window", required_argument, NULL, 808},
     // Must terminate with a NULL entry
     {NULL, 0, NULL, 0},
 };
@@ -910,6 +914,16 @@ bool get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 			// --animation-window-masss
 			opt->animation_window_mass = atof(optarg);
 			break;
+		case 808: {
+			// --animation-for-open-window
+			enum open_window_animation animation = parse_open_window_animation(optarg);
+			if (animation >= OPEN_WINDOW_ANIMATION_INVALID) {
+				log_warn("Invalid open-window animation %s, ignoring.", optarg);
+			} else {
+				opt->animation_for_open_window = animation;
+			}
+			break;
+		}
 		default: usage(argv[0], 1); break;
 #undef P_CASEBOOL
 		}

--- a/src/win.c
+++ b/src/win.c
@@ -1413,6 +1413,42 @@ struct win *add_win_above(session_t *ps, xcb_window_t id, xcb_window_t below) {
 	}
 }
 
+static void init_animation(session_t *ps, struct managed_win *new, struct xcb_get_geometry_reply_t *g) {
+	switch (ps->o.animation_for_open_window) {
+		case OPEN_WINDOW_ANIMATION_NONE: // No animation
+                        new->animation_center_x = g->x + g->width*0.5;
+                        new->animation_center_y = g->y + g->height*0.5;
+                        new->animation_w = g->width;
+                        new->animation_h = g->height;
+                        new->animation_dest_center_x = g->x + g->width*0.5;
+                        new->animation_dest_center_y = g->y + g->height*0.5;
+                        new->animation_dest_w = g->width;
+                        new->animation_dest_h = g->height;
+			break;
+                case OPEN_WINDOW_ANIMATION_FLYIN: { // Fly-in from a random point outside the screen
+			// Compute random point off screen
+			double angle = 2 * M_PI * ((double)rand() / RAND_MAX);
+			const double radius =
+				sqrt(ps->root_width*ps->root_width + ps->root_height*ps->root_height);
+
+			// Set animation
+			new->animation_center_x = ps->root_width*0.5 + radius*cos(angle);
+			new->animation_center_y = ps->root_height*0.5 + radius*sin(angle);
+			new->animation_w = 0;
+			new->animation_h = 0;
+
+			new->animation_dest_center_x = g->x + g->width*0.5;
+			new->animation_dest_center_y = g->y + g->height*0.5;
+			new->animation_dest_w = g->width;
+			new->animation_dest_h = g->height;
+			break;
+		}
+		case OPEN_WINDOW_ANIMATION_INVALID:
+			assert(false);
+			break;
+	}
+}
+
 /// Query the Xorg for information about window `win`
 /// `win` pointer might become invalid after this function returns
 /// Returns the pointer to the window, might be different from `w`
@@ -1573,21 +1609,8 @@ struct win *fill_win(session_t *ps, struct win *w) {
 	    .border_width = g->border_width,
 	};
 
-	// Compute random point off screen
-	double angle = 2 * M_PI * ((double)rand() / RAND_MAX);
-	const double radius =
-	    sqrt(ps->root_width * ps->root_width + ps->root_height * ps->root_height);
-
-	// and init window to fly in from that point
-	new->animation_center_x = ps->root_width * 0.5 + radius *cos(angle);
-	new->animation_center_y = ps->root_height * 0.5 + radius *sin(angle);
-	new->animation_w = 0;
-	new->animation_h = 0;
-
-	new->animation_dest_center_x = g->x + g->width * 0.5;
-	new->animation_dest_center_y = g->y + g->height * 0.5;
-	new->animation_dest_w = g->width;
-	new->animation_dest_h = g->height;
+	// And set window-open animation
+	init_animation(ps, new, g);
 
 	free(g);
 

--- a/src/win.h
+++ b/src/win.h
@@ -171,8 +171,8 @@ struct managed_win {
 	/// Whether this window is in open/close state.
 	bool in_openclose;
 	/// Current position and destination, for animation
-	double animation_x,      animation_y;
-	double animation_dest_x, animation_dest_y;
+	double animation_center_x,      animation_center_y;
+	double animation_dest_center_x, animation_dest_center_y;
 	double animation_w,      animation_h;
 	double animation_dest_w, animation_dest_h;
 	/// Spring animation velocity


### PR DESCRIPTION
Adjusts animations to be with respect to the window center for position
interpolation, which makes things less strange looking when window
scaling takes longer than translating. Also clamps animation size to
window size to resolve blurring artifacts behind the window. Also make
animation fly in from a random direction off screen (:

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
